### PR TITLE
Radify by Annotating - App Graph

### DIFF
--- a/deploy/k8s/helm/basket-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/basket-api/templates/configmap.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: {{ template "basket-api.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.basket }}
 data:
   basket__ConnectionString: {{ .Values.inf.redis.basket.constr }}
   urls__IdentityUrl: http://{{ .Values.app.svc.identity }}

--- a/deploy/k8s/helm/basket-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/basket-api/templates/deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: {{ template "basket-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.basket }}
+    radius.app/connection-identity: {{ .Values.app.svc.identity }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/basket-api/templates/service.yaml
+++ b/deploy/k8s/helm/basket-api/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "basket-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.basket }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/catalog-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/catalog-api/templates/configmap.yaml
@@ -12,6 +12,9 @@ metadata:
     chart: {{ template "catalog-api.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.catalog }}
 data:
   catalog__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.catalog.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   catalog__PicBaseUrl: {{ $protocol }}://{{ $webshoppingapigw }}/c/api/v1/catalog/items/[0]/pic/

--- a/deploy/k8s/helm/catalog-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/catalog-api/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "catalog-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.catalog }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/catalog-api/templates/service.yaml
+++ b/deploy/k8s/helm/catalog-api/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "catalog-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.catalog }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/identity-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/identity-api/templates/configmap.yaml
@@ -19,6 +19,9 @@ metadata:
     chart: {{ template "identity-api.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.identity }}
 data:
   identity__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.identity.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   identity__keystore: {{ .Values.inf.redis.keystore.constr }}

--- a/deploy/k8s/helm/identity-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/identity-api/templates/deployment.yaml
@@ -10,6 +10,14 @@ metadata:
     chart: {{ template "identity-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.identity }}
+    radius.app/connection-webmvc: {{ .Values.app.svc.mvc }}
+    radius.app/connection-basket: {{ .Values.app.svc.basket }}
+    radius.app/connection-ordering: {{ .Values.app.svc.ordering }}
+    radius.app/connection-webhooks: {{ .Values.app.svc.webhooks }}
+    radius.app/connection-webhooksweb: {{ .Values.app.svc.webhooksweb }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/identity-api/templates/ingress-dockerk8s.yaml
+++ b/deploy/k8s/helm/identity-api/templates/ingress-dockerk8s.yaml
@@ -21,6 +21,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- end }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.identity }}
 spec:
   rules:
   - http:

--- a/deploy/k8s/helm/identity-api/templates/ingress.yaml
+++ b/deploy/k8s/helm/identity-api/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}
   annotations:
+    annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.identity }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}

--- a/deploy/k8s/helm/identity-api/templates/service.yaml
+++ b/deploy/k8s/helm/identity-api/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "identity-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.identity }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/mobileshoppingagg/templates/configmap.yaml
+++ b/deploy/k8s/helm/mobileshoppingagg/templates/configmap.yaml
@@ -11,6 +11,9 @@ metadata:
     chart: {{ template "mobileshoppingagg.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.mobileshoppingagg }}
 data:
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
   mobileshoppingagg__keystore: {{ .Values.inf.redis.keystore.constr }}

--- a/deploy/k8s/helm/mobileshoppingagg/templates/deployment.yaml
+++ b/deploy/k8s/helm/mobileshoppingagg/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "mobileshoppingagg.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.mobileshoppingagg }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/mobileshoppingagg/templates/service.yaml
+++ b/deploy/k8s/helm/mobileshoppingagg/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "mobileshoppingagg.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.mobileshoppingagg }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/ordering-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/ordering-api/templates/configmap.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "ordering-api.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.ordering }}
 data:
   ordering__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.ordering.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   urls__IdentityUrl: http://{{ .Values.app.svc.identity }}

--- a/deploy/k8s/helm/ordering-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/ordering-api/templates/deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: {{ template "ordering-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.ordering }}
+    radius.app/connection-identity: {{ .Values.app.svc.identity }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/ordering-api/templates/service.yaml
+++ b/deploy/k8s/helm/ordering-api/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "ordering-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.ordering }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/ordering-backgroundtasks/templates/configmap.yaml
+++ b/deploy/k8s/helm/ordering-backgroundtasks/templates/configmap.yaml
@@ -11,6 +11,9 @@ metadata:
     chart: {{ template "ordering-backgroundtasks.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.orderingbackgroundtasks }}
 data:
   ordering__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.ordering.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   ordering__EnableLoadTest: "{{ .Values.inf.misc.useLoadTest }}"

--- a/deploy/k8s/helm/ordering-backgroundtasks/templates/deployment.yaml
+++ b/deploy/k8s/helm/ordering-backgroundtasks/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "ordering-backgroundtasks.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.orderingbackgroundtasks }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/ordering-backgroundtasks/templates/service.yaml
+++ b/deploy/k8s/helm/ordering-backgroundtasks/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "ordering-backgroundtasks.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.orderingbackgroundtasks }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/ordering-signalrhub/templates/configmap.yaml
+++ b/deploy/k8s/helm/ordering-signalrhub/templates/configmap.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "ordering-signalrhub.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.orderingsignalrhub }}
 data:
   all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"

--- a/deploy/k8s/helm/ordering-signalrhub/templates/deployment.yaml
+++ b/deploy/k8s/helm/ordering-signalrhub/templates/deployment.yaml
@@ -9,6 +9,13 @@ metadata:
     chart: {{ template "ordering-signalrhub.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.orderingsignalrhub }}
+    radius.app/connection-identity: {{ .Values.app.svc.identity }}
+    radius.app/connection-ordering: {{ .Values.app.svc.ordering }}
+    radius.app/connection-catalog: {{ .Values.app.svc.catalog }}
+    radius.app/connection-basket: {{ .Values.app.svc.basket }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/ordering-signalrhub/templates/service.yaml
+++ b/deploy/k8s/helm/ordering-signalrhub/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "ordering-signalrhub.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.orderingsignalrhub }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/payment-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/payment-api/templates/configmap.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: {{ template "payment-api.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.payment }}
 data:
   all__EventBusConnection: {{ .Values.inf.eventbus.constr }}
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"

--- a/deploy/k8s/helm/payment-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/payment-api/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ template "payment-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.payment }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/payment-api/templates/service.yaml
+++ b/deploy/k8s/helm/payment-api/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "payment-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.payment }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/webhooks-api/templates/configmap.yaml
+++ b/deploy/k8s/helm/webhooks-api/templates/configmap.yaml
@@ -12,6 +12,9 @@ metadata:
     chart: {{ template "webhooks-api.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webhooks }}
 data:
   webhooks__ConnectionString: Server={{ $sqlsrv }};Initial Catalog={{ .Values.inf.sql.webhooks.db }};User Id={{ .Values.inf.sql.common.user }};Password={{ .Values.inf.sql.common.pwd }};TrustServerCertificate={{ .Values.inf.sql.common.TrustServerCertificate }};
   urls__IdentityUrl: http://{{ $identity }}

--- a/deploy/k8s/helm/webhooks-api/templates/deployment.yaml
+++ b/deploy/k8s/helm/webhooks-api/templates/deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: {{ template "webhooks-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webhooks }}
+    radius.app/connection-identity: {{ .Values.app.svc.identity }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/webhooks-api/templates/ingress.yaml
+++ b/deploy/k8s/helm/webhooks-api/templates/ingress.yaml
@@ -12,6 +12,8 @@ metadata:
     heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}
   annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webhooks }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}

--- a/deploy/k8s/helm/webhooks-api/templates/service.yaml
+++ b/deploy/k8s/helm/webhooks-api/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "webhooks-api.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webhooks }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/webhooks-web/templates/configmap.yaml
+++ b/deploy/k8s/helm/webhooks-web/templates/configmap.yaml
@@ -13,6 +13,9 @@ metadata:
     chart: {{ template "webhooks-web.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webhooksweb }}
 data:
   urls__webhooks: {{ $protocol }}://{{ $webhooks }}
   identity_e: {{ $protocol }}://{{ $identity }}

--- a/deploy/k8s/helm/webhooks-web/templates/deployment.yaml
+++ b/deploy/k8s/helm/webhooks-web/templates/deployment.yaml
@@ -10,6 +10,11 @@ metadata:
     chart: {{ template "webhooks-web.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webhooksweb }}
+    radius.app/connection-identity: {{ .Values.app.svc.identity }}
+    radius.app/connection-webhooks: {{ .Values.app.svc.webhooks }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/webhooks-web/templates/ingress.yaml
+++ b/deploy/k8s/helm/webhooks-web/templates/ingress.yaml
@@ -13,6 +13,8 @@ metadata:
     heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}
   annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webhooksweb }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}

--- a/deploy/k8s/helm/webmvc/templates/configmap.yaml
+++ b/deploy/k8s/helm/webmvc/templates/configmap.yaml
@@ -13,6 +13,9 @@ metadata:
     chart: {{ template "webmvc.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.mvc }}
 data:
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
   all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"

--- a/deploy/k8s/helm/webmvc/templates/deployment.yaml
+++ b/deploy/k8s/helm/webmvc/templates/deployment.yaml
@@ -10,6 +10,12 @@ metadata:
     chart: {{ template "webmvc.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.mvc }}
+    radius.app/connection-identity: {{ .Values.app.svc.identity }}
+    radius.app/connection-webshoppingagg: {{ .Values.app.svc.webshoppingagg }}
+    radius.app/connection-orderingsignalrhub: {{ .Values.app.svc.orderingsignalrhub }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/webmvc/templates/ingress-dockerk8s.yaml
+++ b/deploy/k8s/helm/webmvc/templates/ingress-dockerk8s.yaml
@@ -14,6 +14,8 @@ metadata:
     heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}
   annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.mvc }}
 {{ toYaml . | indent 4 }}
 {{- end }}    
 {{- if .Values.inf.mesh.enabled }} 

--- a/deploy/k8s/helm/webmvc/templates/ingress.yaml
+++ b/deploy/k8s/helm/webmvc/templates/ingress.yaml
@@ -12,6 +12,8 @@ metadata:
     heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}
   annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.mvc }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}

--- a/deploy/k8s/helm/webmvc/templates/service.yaml
+++ b/deploy/k8s/helm/webmvc/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "webmvc.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.mvc }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/webshoppingagg/templates/configmap.yaml
+++ b/deploy/k8s/helm/webshoppingagg/templates/configmap.yaml
@@ -11,6 +11,9 @@ metadata:
     chart: {{ template "webshoppingagg.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webshoppingagg }}
 data:
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
   webshoppingagg__keystore: {{ .Values.inf.redis.keystore.constr }}

--- a/deploy/k8s/helm/webshoppingagg/templates/deployment.yaml
+++ b/deploy/k8s/helm/webshoppingagg/templates/deployment.yaml
@@ -9,6 +9,13 @@ metadata:
     chart: {{ template "webshoppingagg.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}    
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webshoppingagg }}
+    radius.app/connection-identity: {{ .Values.app.svc.identity }}
+    radius.app/connection-ordering: {{ .Values.app.svc.ordering }}
+    radius.app/connection-catalog: {{ .Values.app.svc.catalog }}
+    radius.app/connection-basket: {{ .Values.app.svc.basket }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/webshoppingagg/templates/service.yaml
+++ b/deploy/k8s/helm/webshoppingagg/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "webshoppingagg.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.webshoppingagg }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/webspa/templates/configmap.yaml
+++ b/deploy/k8s/helm/webspa/templates/configmap.yaml
@@ -14,6 +14,9 @@ metadata:
     chart: {{ template "webspa.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.spa }}
 data:
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
   webspa__keystore: {{ .Values.inf.redis.keystore.constr }}

--- a/deploy/k8s/helm/webspa/templates/deployment.yaml
+++ b/deploy/k8s/helm/webspa/templates/deployment.yaml
@@ -10,6 +10,12 @@ metadata:
     chart: {{ template "webspa.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.spa }}
+    radius.app/connection-identity: {{ .Values.app.svc.identity }}
+    radius.app/connection-webshoppingagg: {{ .Values.app.svc.webshoppingagg }}
+    radius.app/connection-orderingsignalrhub: {{ .Values.app.svc.orderingsignalrhub }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/webspa/templates/ingress.yaml
+++ b/deploy/k8s/helm/webspa/templates/ingress.yaml
@@ -13,6 +13,8 @@ metadata:
     heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}
   annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.spa }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}

--- a/deploy/k8s/helm/webspa/templates/service.yaml
+++ b/deploy/k8s/helm/webspa/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "webspa.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.spa }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/k8s/helm/webstatus/templates/configmap.yaml
+++ b/deploy/k8s/helm/webstatus/templates/configmap.yaml
@@ -13,6 +13,9 @@ metadata:
     chart: {{ template "webstatus.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.status }}
 data:
   all__InstrumentationKey: "{{ .Values.inf.appinsights.key }}"
   all__UseAzureServiceBus: "{{ .Values.inf.eventbus.useAzure }}"

--- a/deploy/k8s/helm/webstatus/templates/deployment.yaml
+++ b/deploy/k8s/helm/webstatus/templates/deployment.yaml
@@ -10,6 +10,17 @@ metadata:
     chart: {{ template "webstatus.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.status }}
+    radius.app/connection-identity: {{ .Values.app.svc.identity }}
+    radius.app/connection-basket: {{ .Values.app.svc.basket }}
+    radius.app/connection-catalog: {{ .Values.app.svc.catalog }}
+    radius.app/connection-payment: {{ .Values.app.svc.payment }}
+    radius.app/connection-ordering: {{ .Values.app.svc.ordering }}
+    radius.app/connection-orderingsignalrhub: {{ .Values.app.svc.orderingsignalrhub }}
+    radius.app/connection-orderingbackgroundtasks: {{ .Values.app.svc.orderingbackgroundtasks }}
+    radius.app/connection-webshoppingagg: {{ .Values.app.svc.webshoppingagg }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/k8s/helm/webstatus/templates/ingress.yaml
+++ b/deploy/k8s/helm/webstatus/templates/ingress.yaml
@@ -14,6 +14,8 @@ metadata:
     heritage: {{ .Release.Service }}
 {{- with .Values.ingress.annotations }}
   annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.status }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- if and .Values.inf.tls.enabled .Values.inf.tls.issuer }}

--- a/deploy/k8s/helm/webstatus/templates/service.yaml
+++ b/deploy/k8s/helm/webstatus/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "webstatus.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    radius.app/application: {{ .Values.app.name }}
+    radius.app/name: {{ .Values.app.svc.status }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
This PR radifies eShop on containers by annotating the existing Helm charts. This PR includes adds the resources to the app graph and adds connections between the services. 

Recipes is not included in this PR